### PR TITLE
Include historical tick message forwarding in tick by tick request handler

### DIFF
--- a/crates/ib_tws_core/src/async_client.rs
+++ b/crates/ib_tws_core/src/async_client.rs
@@ -372,7 +372,8 @@ impl AsyncClient {
                     | Response::TickByTickAllLastMsg(_)
                     | Response::TickByTickMidPointMsg(_)
                     | Response::HistoricalTickLastMsg(_)
-                    | Response::HistoricalTickBidAskMsg(_)) => Some(Ok(response)),
+                    | Response::HistoricalTickBidAskMsg(_)
+                    | Response::HistoricalTicksMsg(_)) => Some(Ok(response)),
                     _ => None,
                 }
             }))

--- a/crates/ib_tws_core/src/async_client.rs
+++ b/crates/ib_tws_core/src/async_client.rs
@@ -370,7 +370,9 @@ impl AsyncClient {
                     response @ (Response::TickByTickNoneMsg(_)
                     | Response::TickByTickBidAskMsg(_)
                     | Response::TickByTickAllLastMsg(_)
-                    | Response::TickByTickMidPointMsg(_)) => Some(Ok(response)),
+                    | Response::TickByTickMidPointMsg(_)
+                    | Response::HistoricalTickLastMsg(_)
+                    | Response::HistoricalTickBidAskMsg(_)) => Some(Ok(response)),
                     _ => None,
                 }
             }))

--- a/crates/ib_tws_core/src/message/wire.rs
+++ b/crates/ib_tws_core/src/message/wire.rs
@@ -53,7 +53,12 @@ pub trait TwsWireEncoder {
 
     #[inline(always)]
     fn push_double(&mut self, v: f64) {
-        self.push_string(&v.to_string());
+        // This is what the java client sends
+        if v == f64::MAX {
+            self.push_string("1.7976931348623157E308");
+        } else {
+            self.push_string(&v.to_string());
+        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
The `tick_by_tick` API includes a parameter to request historical ticks:

https://interactivebrokers.github.io/tws-api/tick_data.html

> Additionally, if a non-zero value is input for the argument numberOfTicks in [IBApi::EClient::reqTickByTickData](https://interactivebrokers.github.io/tws-api/classIBApi_1_1EClient.html#a3ab310450f1261accd706f69766b2263), historical tick data is first returned to one of the functions [IBApi::EWrapper::historicalTicksLast](https://interactivebrokers.github.io/tws-api/interfaceIBApi_1_1EWrapper.html#a0d0c407b72a8ae93a7b65818eaf63381), [IBApi::EWrapper::historicalTicksBidAsk](https://interactivebrokers.github.io/tws-api/interfaceIBApi_1_1EWrapper.html#aceda2894391ebddeb4409447fc453a4b), or [IBApi::EWrapper::historicalTicks](https://interactivebrokers.github.io/tws-api/interfaceIBApi_1_1EWrapper.html#aaef348882e2a2c1c21ad8dd2167b2229), respectively.

This will include the historical ticks when requested.